### PR TITLE
Use since query argument instead of last-event-id

### DIFF
--- a/src/couchdb-change-events.js
+++ b/src/couchdb-change-events.js
@@ -139,7 +139,7 @@ class CouchdbChangeEvents extends EventEmitter {
 		if (this.lastEventId) {
 			let lastEventId = encodeURIComponent(this.lastEventId);
 
-			couchDbPath += `&last-event-id=${lastEventId}`;
+			couchDbPath += `&since=${lastEventId}`;
 		}
 
 		if (this.user) {

--- a/test/couchdb-change-events.utest.js
+++ b/test/couchdb-change-events.utest.js
@@ -526,7 +526,7 @@ describe('CouchdbChangeEvents', () => {
 			should.equal(
 				changeEvents.getRequestOptions().path,
 				`/my_database/_changes?feed=continuous&heartbeat=2000` +
-				`&include_docs=true&last-event-id=32-dsjfa`
+				`&include_docs=true&since=32-dsjfa`
 			);
 		});
 
@@ -553,7 +553,7 @@ describe('CouchdbChangeEvents', () => {
 			should.equal(
 				changeEvents.getRequestOptions().path,
 				`/my_database%2F/_changes?feed=continuous&heartbeat=2000` +
-				`&include_docs=true&last-event-id=82-%2F`
+				`&include_docs=true&since=82-%2F`
 			);
 		});
 


### PR DESCRIPTION
It's basically the same thing, except you can pass the string "now" as a ```since``` value to get new changes only, even when you don't know the last sequence id.