### PR TITLE
Fixed: JSON.parse of change when value contains special characters like single quotes

### DIFF
--- a/src/couchdb-change-events.js
+++ b/src/couchdb-change-events.js
@@ -108,7 +108,11 @@ class CouchdbChangeEvents extends EventEmitter {
 
 		if (messages.length > 0) {
 			for (let change of messages) {
-				let couchdbChange = JSON.parse(change);
+				let couchdbChange = JSON.parse(change, (key, value) =>
+					typeof value === 'string'
+					? value.replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0')
+					: value
+				);
 
 				if (couchdbChange.error) {
 					const error = new Error(couchdbChange.error);


### PR DESCRIPTION
This pull request fix the following problem : 
When bodyDoc json values contains special characters like single quote '
JSON.parse break with ERROR !

In my fix I replace special characters with escaped sequence, adding "reviver" parameter to JSON.parse call as you can see in JSON.parse doc : https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/JSON/parse

I hope you accept thi pull request cause I would like to use your module but I can't use it withour this workaround !

Thank you :) 